### PR TITLE
Update README.md for iOS 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplication.Op
   return true
 }
 ```
+- On iOS 13, UIKit will notify `UISceneDelegate` instead of `UIApplicationDelegate`.
+- Implement `UISceneDelegate` method
+```swift
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else {
+            return
+        }
+        if (url.host == "oauth-callback") {
+            OAuthSwift.handle(url: url)
+        }
+}
+```
+
 :warning: Any other application may try to open a URL with your url scheme. So you can check the source application, for instance for safari controller :
 ```
 if (options[.sourceApplication] as? String == "com.apple.SafariViewService") {


### PR DESCRIPTION
Before iOS 13, If a URL arrives while your app is suspended or running in the background, the system moves your app to the foreground prior to calling `application(_:open:options:)`. After Apple introduced `UISceneDelegate`, now system calls `scene(_:openURLContexts:)` when a URL arrives.

The readme section of **Handle URL in AppDelegate** revised accordingly.